### PR TITLE
support custom regexp for collapse libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ require("better-stack-traces").install({
   before: 2, // number of lines to show above the error
   after: 3, // number of lines to show below the error
   maxColumns: 80, // maximum number of columns to output in code snippets
-  collapseLibraries: true // omit code snippets from node_modules
+  collapseLibraries: /node_modules/ // omit code snippets from paths that match the given regexp (ignores node_modules by default)
 })
 ```
 

--- a/better-stack-traces.js
+++ b/better-stack-traces.js
@@ -42,7 +42,7 @@ function BetterStackTrace(error, frames, opt) {
 
   // Parse flags.
   opt = opt || {};
-  this._collapseLibraries = fallback(opt.collapseLibraries, true);
+  this._collapseLibraries = fallback(opt.collapseLibraries, /node_modules/);
   this._linesBefore = fallback(opt.before, LINES_BEFORE);
   this._linesAfter = fallback(opt.after, LINES_AFTER);
   this._maxColumns = opt.maxColumns || MAX_COLUMNS;
@@ -187,7 +187,7 @@ BetterStackTrace.prototype = {
             fileLocation += ":" + columnNumber;
           }
           try {
-            if (this._collapseLibraries && /node_modules/.test(fileName)) {
+            if (this._collapseLibraries && this._collapseLibraries.test(fileName)) {
               context = null;
             } else {
               context = this._formatContext(fileName, lineNumber, columnNumber);


### PR DESCRIPTION
By working locally here sometimes I have node_modules installed as symbolic links, and when it happens the resolved path of the library end up being without "node_modules" in path, so I just extended the collapseLibraries to accept and use a custom regular extension to match library paths
