### PR TITLE
Make CoffeeScript optional

### DIFF
--- a/better-stack-traces.js
+++ b/better-stack-traces.js
@@ -87,7 +87,7 @@ BetterStackTrace.prototype = {
       code = this._fs.readFileSync(fileName).toString();
       if (/\.coffee$/.test(fileName)) {
         if (this._coffee) {
-          code = this._compileCoffeScript(code);
+          code = this._compileCoffeeScript(code);
         } else {
           throw new Error("CoffeeScript compiler unavailable, did you include it in your dependencies?");
         }
@@ -97,7 +97,7 @@ BetterStackTrace.prototype = {
     return code;
   },
 
-  _compileCoffeScript: function _compileCoffeScript(code) {
+  _compileCoffeeScript: function _compileCoffeeScript(code) {
     if (this._coffee) {
       return this._coffee.compile(code);
     } else {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "repository": {
         "url": "https://github.com/mjpizz/better-stack-traces"
     },
-    "dependencies": {
+    "optionalDependencies": {
       "coffee-script": "*"
     },
     "main": "./better-stack-traces"


### PR DESCRIPTION
Supports request from #4 to make the `coffee-script` dependency optional. Will show a warning if you don't have coffee-script but the trace parser somehow still encounters a coffee file.

@StreetStrider Look good to you?